### PR TITLE
fix adding interfaces LAN bug of German interface

### DIFF
--- a/src/www/interfaces_assign.php
+++ b/src/www/interfaces_assign.php
@@ -136,7 +136,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         /* find next free optional interface number */
         if(empty($config['interfaces']['lan'])) {
-            $newifname = gettext("lan");
+            $newifname = 'lan';
             $descr = gettext("LAN");
         } else {
             for ($i = 1; $i <= count($config['interfaces']); $i++) {


### PR DESCRIPTION
The XML variable name ($newifname) should always be "lan" (written in lowercase letters). This commit removes the gettext translation function for the variable name. With the former behaviour, removing the LAN interface and trying to add new (optional) interfaces was broken when a user had switched the interface language to German (the variable name was translated to "LAN" in capital letters, which caused any new interface to overwrite this "LAN" entry).